### PR TITLE
Read WorkGraph data from `attributes` instead of `base.extras`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
         -   name: Install aiida-core
             run: pip install aiida-core==${{ matrix.aiida-core-version }}
 
+        -   name: Install aiida-workgraph
+            run: pip install git+https://github.com/aiidateam/aiida-workgraph.git
+
         -   name: Install Python dependencies
             run: |
                 pip install -e .[pre-commit,tests]

--- a/aiida_workgraph_web_ui/backend/app/utils.py
+++ b/aiida_workgraph_web_ui/backend/app/utils.py
@@ -8,9 +8,9 @@ from dateutil.tz import tzlocal
 def get_executor_source(tdata: Any) -> Tuple[bool, Optional[str]]:
     """Get the source code of the executor."""
     import inspect
-    from aiida_workgraph.utils import get_executor
+    from node_graph.executor import NodeExecutor
 
-    executor, _ = get_executor(tdata["executor"])
+    executor = NodeExecutor(**tdata["executor"]).executor
     if callable(executor):
         try:
             source_lines, _ = inspect.getsourcelines(executor)

--- a/aiida_workgraph_web_ui/backend/app/workgraph.py
+++ b/aiida_workgraph_web_ui/backend/app/workgraph.py
@@ -38,21 +38,13 @@ async def read_workgraph_data(search: str = Query(None)):
 async def read_workgraph_task(id: int, node_name: str):
     from .utils import node_to_short_json
     from aiida.orm.utils.serialize import deserialize_unsafe
-    from aiida.orm import QueryBuilder
-    from aiida_workgraph.engine.workgraph import WorkGraphEngine
+    from aiida.orm import load_node
 
     try:
         tstart = time.time()
-        qb = QueryBuilder()
-        projections = [f"extras._workgraph.tasks.{node_name}"]
-        qb.append(
-            WorkGraphEngine, filters={"id": id}, project=projections, tag="process"
-        )
-        results = qb.all()
-        if len(results) == 0:
-            print("No workgraph data found in the node.")
-            return
-        ndata = deserialize_unsafe(results[0][0])
+        node = load_node(id)
+        ndata = node.workgraph_data["tasks"][node_name]
+        ndata = deserialize_unsafe(ndata)
         content = node_to_short_json(id, ndata)
         print(f"Time to convert to json: {time.time() - tstart}")
         tstart = time.time()
@@ -77,7 +69,7 @@ async def read_workgraph(id: int):
 
         node = orm.load_node(id)
 
-        content = node.base.extras.get("_workgraph_short", None)
+        content = node.workgraph_data_short
         if content is None:
             print("No workgraph data found in the node.")
             return

--- a/aiida_workgraph_web_ui/backend/app/workgraph.py
+++ b/aiida_workgraph_web_ui/backend/app/workgraph.py
@@ -45,6 +45,8 @@ async def read_workgraph_task(id: int, node_name: str):
         node = load_node(id)
         ndata = node.workgraph_data["tasks"][node_name]
         ndata = deserialize_unsafe(ndata)
+        executor = node.task_executors.get(node_name, None)
+        ndata["executor"] = executor if executor else {}
         content = node_to_short_json(id, ndata)
         print(f"Time to convert to json: {time.time() - tstart}")
         tstart = time.time()

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,8 @@
+name: base
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - aiida-core
+  - aiida-core.services
+  - qe


### PR DESCRIPTION
After PR https://github.com/aiidateam/aiida-workgraph/pull/410, WorkGraph saves the data into `attributes` instead of `base.extras`.