### PR TITLE
Set up a proxy in the package.json to handle API requests during development

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "workgraph",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -42,7 +42,7 @@ function AppContent({error }) {
           <Route path="/process" element={<ProcessTable />} />
           <Route path="/process/:pk/*" element={<ProcessNodeDetail />} />
           <Route path="/daemon" element={<Daemon />} />
-          <Route path="/workchain/:pk/*" element={<WorkFlowItem endPoint="http://localhost:8000/api/workchain" />} />
+          <Route path="/workchain/:pk/*" element={<WorkFlowItem endPoint="/api/workchain" />} />
           <Route path="/datanode" element={<DataNodeTable />} />
           <Route path="/datanode/:pk" element={<DataNodeItem />} />
           <Route path="/groupnode" element={<GroupNodeTable />} />
@@ -74,7 +74,7 @@ export default function App() {
 
   // Fetch installed plugin IDs once
   useEffect(() => {
-    fetch('http://localhost:8000/plugins')
+    fetch('/plugins')
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();

--- a/frontend/src/components/Daemon.js
+++ b/frontend/src/components/Daemon.js
@@ -6,7 +6,7 @@ function Settings() {
   const [workers, setWorkers] = useState([]);
 
   const fetchWorkers = () => {
-    fetch('http://localhost:8000/api/daemon/worker')
+    fetch('/api/daemon/worker')
       .then(response => response.json())
       .then(data => setWorkers(Object.values(data)))
       .catch(error => console.error('Failed to fetch workers:', error));
@@ -19,7 +19,7 @@ function Settings() {
   }, []);
 
   const handleDaemonControl = (action) => {
-    fetch(`http://localhost:8000/api/daemon/${action}`, { method: 'POST' })
+    fetch(`/api/daemon/${action}`, { method: 'POST' })
       .then(response => {
         if (!response.ok) {
           throw new Error(`Daemon operation failed: ${response.statusText}`);
@@ -34,7 +34,7 @@ function Settings() {
   };
 
   const adjustWorkers = (action) => {
-    fetch(`http://localhost:8000/api/daemon/${action}`, { method: 'POST' })
+    fetch(`/api/daemon/${action}`, { method: 'POST' })
       .then(response => {
         if (!response.ok) {
           throw new Error(`Failed to ${action} workers: ${response.statusText}`);

--- a/frontend/src/components/DataNodeItem.tsx
+++ b/frontend/src/components/DataNodeItem.tsx
@@ -10,7 +10,7 @@ function DataNodeItem() {
   const [NodeData, setNodeData] = useState({ node_type: "" });
 
   useEffect(() => {
-    fetch(`http://localhost:8000/api/datanode/${pk}`)
+    fetch(`/api/datanode/${pk}`)
       .then(response => response.json())
       .then(data => {
         setNodeData(data);

--- a/frontend/src/components/DataNodeTable.js
+++ b/frontend/src/components/DataNodeTable.js
@@ -13,7 +13,7 @@ const dataColumns = linkPrefix => ([
 export default () =>
   <NodeTable
     title="Data nodes"
-    endpointBase="http://localhost:8000/api/datanode"
+    endpointBase="/api/datanode"
     linkPrefix="/datanode"
     config={{
       columns       : dataColumns,

--- a/frontend/src/components/GroupNodeDetail.jsx
+++ b/frontend/src/components/GroupNodeDetail.jsx
@@ -91,7 +91,7 @@ export default function GroupNodeDetail() {
   };
 
   useEffect(() => {
-    fetch(`http://localhost:8000/api/groupnode/${pk}`)
+    fetch(`/api/groupnode/${pk}`)
     .then(async (r) => {
       if (!r.ok) {
         const errorText = await r.text();
@@ -107,7 +107,7 @@ export default function GroupNodeDetail() {
   }, [pk]);
 
   const endpointBase = useMemo(
-    () => `http://localhost:8000/api/groupnode/${pk}/members`,
+    () => `/api/groupnode/${pk}/members`,
     [pk]
   );
 

--- a/frontend/src/components/GroupNodeTable.js
+++ b/frontend/src/components/GroupNodeTable.js
@@ -15,7 +15,7 @@ const groupColumns = linkPrefix => ([
 export default () =>
   <NodeTable
     title="Group nodes"
-    endpointBase="http://localhost:8000/api/groupnode"
+    endpointBase="/api/groupnode"
     linkPrefix="/groupnode"
     config={{
       columns       : groupColumns,

--- a/frontend/src/components/PluginContext.jsx
+++ b/frontend/src/components/PluginContext.jsx
@@ -35,7 +35,7 @@ export function PluginProvider({ pluginNames, children }) {
       for (const name of pluginNames) {
         try {
           const mod = await import(
-            /* webpackIgnore: true */ `http://localhost:8000/plugins/${name}/static/${name}.esm.js`
+            /* webpackIgnore: true */ `/plugins/${name}/static/${name}.esm.js`
           );
           const def = mod.default || mod;
           if (def.dataView) Object.assign(mergedDataViews, def.dataView);

--- a/frontend/src/components/ProcessDuration.js
+++ b/frontend/src/components/ProcessDuration.js
@@ -14,7 +14,7 @@ const NodeDurationGraph = ({ id }) => {
 
     const fetchData = async () => {
         try {
-            const response = await fetch(`http://localhost:8000/api/workchain-state/${id}?item_type=${useItemType}`);
+            const response = await fetch(`/api/workchain-state/${id}?item_type=${useItemType}`);
             if (!response.ok) {
                 throw new Error('Network response was not ok');
             }

--- a/frontend/src/components/ProcessItem.tsx
+++ b/frontend/src/components/ProcessItem.tsx
@@ -12,7 +12,7 @@ export default function Process() {
 
   /* fetch once */
   useEffect(() => {
-    fetch(`http://localhost:8000/api/process/${pk}`)
+    fetch(`/api/process/${pk}`)
       .then(r => r.json())
       .then(setSummary);
   }, [pk]);

--- a/frontend/src/components/ProcessLog.js
+++ b/frontend/src/components/ProcessLog.js
@@ -42,7 +42,7 @@ function ProcessLog({ id }) {
 
   const fetchLogs = async () => {
     try {
-      const response = await fetch(`http://localhost:8000/api/process-logs/${id}`);
+      const response = await fetch(`/api/process-logs/${id}`);
       const data = await response.json();
       setFetchedLogs(data);
     } catch (error) {

--- a/frontend/src/components/ProcessTable.jsx
+++ b/frontend/src/components/ProcessTable.jsx
@@ -126,9 +126,9 @@ export function ProcessTable() {
     return (
       <NodeTable
         title="Process nodes"
-        endpointBase="http://localhost:8000/api/process"
+        endpointBase="/api/process"
         linkPrefix="/process"
-        actionBase={`http://localhost:8000/api/process`}
+        actionBase={`/api/process`}
         config={{
           columns       : processColumns,
           buildExtraActions: extraActions,

--- a/frontend/src/components/WorkFlowItem.tsx
+++ b/frontend/src/components/WorkFlowItem.tsx
@@ -216,9 +216,9 @@ function WorkflowItem({endPoint = 'workchain'}) {
             // Fetch data from the backend
             let url;
             if (subPath) {
-              url = `http://localhost:8000/api/task/${pk}/${subPath}/${node.label}`;
+              url = `/api/task/${pk}/${subPath}/${node.label}`;
             } else {
-              url = `http://localhost:8000/api/task/${pk}/${node.label}`;
+              url = `/api/task/${pk}/${node.label}`;
             }
             console.log('Fetching data from:', url);
             const response = await fetch(url);
@@ -272,7 +272,7 @@ function WorkflowItem({endPoint = 'workchain'}) {
         console.log(nodePayload); // Good for debugging
 
         try {
-            const response = await fetch(`http://localhost:8000/api/process/tasks/${action}/${pk}`, {
+            const response = await fetch(`/api/process/tasks/${action}/${pk}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -163,10 +163,10 @@ def browser():
 # Define a fixture for the page
 @pytest.fixture(scope="module")
 def page(browser):
-    with browser.new_page() as page:
-        # 5 seconds
-        page.set_default_timeout(5_000)
-        page.set_default_navigation_timeout(5_000)
-        expect.set_options(timeout=5_000)
-        yield page
-        page.close()
+    with browser.new_context(base_url="http://localhost:8000") as context:
+        # open a new tab/page in that context
+        with context.new_page() as page:
+            page.set_default_timeout(5_000)
+            page.set_default_navigation_timeout(5_000)
+            expect.set_options(timeout=5_000)
+            yield page

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -5,7 +5,7 @@ from playwright.sync_api import expect
 
 @pytest.mark.frontend
 def test_homepage(web_server, page):
-    page.goto("http://localhost:8000")
+    page.goto("")
     assert page.title() == "AiiDA GUI"
 
     # Check if at least one of the links to Process is visible
@@ -18,7 +18,7 @@ def test_homepage(web_server, page):
 
 @pytest.mark.frontend
 def test_process(web_server, page, ran_workchain):
-    page.goto("http://localhost:8000")
+    page.goto("")
     page.click('a[href="/process"]')
 
     # Check for Process Table Header
@@ -49,7 +49,7 @@ def test_process(web_server, page, ran_workchain):
 
 @pytest.mark.frontend
 def test_process_item(web_server, page, ran_workchain):
-    page.goto("http://localhost:8000/process/")
+    page.goto("/process/")
     page.get_by_role("link", name=str(ran_workchain.pk), exact=True).click()
 
     task_name = f"CALL-{ran_workchain.called_descendants[0].pk}"
@@ -117,7 +117,7 @@ def test_process_item(web_server, page, ran_workchain):
 
 @pytest.mark.frontend
 def test_datanode_item(web_server, page, ran_workchain):
-    page.goto("http://localhost:8000/datanode/")
+    page.goto("/datanode/")
     # Check for Table Headers in DataGrid
     expect(page.get_by_role("columnheader", name="PK")).to_be_visible(timeout=10000)
     expect(page.get_by_role("columnheader", name="Created")).to_be_visible(
@@ -140,7 +140,7 @@ def test_datanode_item(web_server, page, ran_workchain):
 
 @pytest.mark.frontend
 def test_daemon(web_server, page, ran_workchain):
-    page.goto("http://localhost:8000/daemon/")
+    page.goto("/daemon/")
     # Verify that only one row is visible
     expect(page.locator(":nth-match(tr, 1)")).to_be_visible()
     expect(page.locator(":nth-match(tr, 2)")).to_be_hidden()
@@ -175,7 +175,7 @@ def test_daemon(web_server, page, ran_workchain):
 @pytest.mark.frontend
 def test_process_delete(web_server, page, ran_workchain):
     """Tests deleting the last process in DataGrid, accounting for pagination."""
-    page.goto("http://localhost:8000/process")
+    page.goto("/process")
 
     # Locate the last row and capture its unique PK from the link
     last_row = page.get_by_role("row").last
@@ -201,7 +201,7 @@ def test_process_delete(web_server, page, ran_workchain):
 @pytest.mark.frontend
 def test_datanode_delete(web_server, page, ran_workchain):
     """Tests deleting the last DataNode in DataGrid, accounting for pagination."""
-    page.goto("http://localhost:8000/datanode")
+    page.goto("/datanode")
 
     # Locate the last row and capture its unique PK from the link
     last_row = page.get_by_role("row").last


### PR DESCRIPTION
In this way, the frontend only uses relative paths, instead of hard-coding the base URL.