### PR TITLE
Security: bind app to localhost only  

### DIFF
--- a/aiida_gui/cmd_web.py
+++ b/aiida_gui/cmd_web.py
@@ -49,7 +49,7 @@ def start(watch, background):
         "uvicorn",
         "aiida_gui.app.api:app",
         "--host",
-        "0.0.0.0",
+        "127.0.0.1",
         "--port",
         "8000",
     ]

--- a/aiida_gui/main.py
+++ b/aiida_gui/main.py
@@ -2,4 +2,4 @@ import uvicorn
 
 
 if __name__ == "__main__":
-    uvicorn.run("app.api:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.api:app", host="127.0.0.1", port=8000, reload=True)

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -88,7 +88,7 @@ def ran_workchain(
 def uvicorn_configuration():
     return {
         "app": "aiida_gui.app.api:app",
-        "host": "0.0.0.0",
+        "host": "127.0.0.1",
         "port": 8000,
         "log_level": "info",
         "workers": 2,


### PR DESCRIPTION
Hi @superstar54 , @giovannipizzi! 

Currently, the app binds to 0.0.0.0, which exposes port 8000 directly to the internet. This is a security risk, as it allows unauthenticated access from any external source. 

This PR changes the binding address to 127.0.0.1, so the application now listens only on localhost.

If external access is needed, it should be handled securely via a reverse proxy like Nginx — which can enforce authentication and other security controls.